### PR TITLE
Deleting Gdx.gl.glBlendFuncSeparate

### DIFF
--- a/src/com/nilunder/bdx/gl/BDXShaderProvider.java
+++ b/src/com/nilunder/bdx/gl/BDXShaderProvider.java
@@ -32,7 +32,13 @@ class BDXDefaultShader extends DefaultShader {
 
 	public void render(Renderable renderable, Attributes combinedAttributes)
 	{
-		BlendingAttribute ba = (BlendingAttribute) renderable.material.get(BlendingAttribute.Type);
+		if(renderable.material.has(BlendingAttribute.Type)) {
+
+			BlendingAttribute ba = (BlendingAttribute) renderable.material.get(BlendingAttribute.Type);
+
+			Gdx.gl.glBlendFuncSeparate(ba.sourceFunction, ba.destFunction, GL20.GL_ONE, GL20.GL_ONE_MINUS_SRC_ALPHA);
+
+		}
 
 		IntAttribute shadeless = (IntAttribute) renderable.material.get(Scene.BDXIntAttribute.Shadeless);
 

--- a/src/com/nilunder/bdx/gl/BDXShaderProvider.java
+++ b/src/com/nilunder/bdx/gl/BDXShaderProvider.java
@@ -34,8 +34,6 @@ class BDXDefaultShader extends DefaultShader {
 	{
 		BlendingAttribute ba = (BlendingAttribute) renderable.material.get(BlendingAttribute.Type);
 
-		Gdx.gl.glBlendFuncSeparate(ba.sourceFunction, ba.destFunction, GL20.GL_ONE, GL20.GL_ONE_MINUS_SRC_ALPHA);
-
 		IntAttribute shadeless = (IntAttribute) renderable.material.get(Scene.BDXIntAttribute.Shadeless);
 
 		if (shadeless == null)


### PR DESCRIPTION
Now I can switch manually ModelInstance attached to GameObject for one generated from g3db converter. Wow! Animated models in BDX!